### PR TITLE
feat(config): maximize Bedrock model configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,50 @@ agent.tool.strand(
 )
 ```
 
+## Model Configuration
+
+### Optimized Defaults
+
+Strands comes with optimized, maxed-out configuration settings for the Bedrock model provider:
+
+```json
+{
+    "model_id": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "max_tokens": 64000,
+    "boto_client_config": {
+        "read_timeout": 900,
+        "connect_timeout": 900,
+        "retries": {
+            "max_attempts": 3,
+            "mode": "adaptive"
+        }
+    },
+    "additional_request_fields": {
+        "thinking": {
+            "type": "enabled",
+            "budget_tokens": 2048
+        }
+    }
+}
+```
+
+These settings provide:
+- Claude 3.7 Sonnet (latest high-performance model)
+- Maximum token output (64,000 tokens)
+- Extended timeouts (15 minutes) for complex operations
+- Automatic retries with adaptive backoff
+- Enabled thinking capability with 2,048 token budget for recursive reasoning
+
+You can customize these values using environment variables:
+
+```bash
+# Maximum tokens for responses
+export STRANDS_MAX_TOKENS=32000
+
+# Budget for agent thinking/reasoning
+export STRANDS_BUDGET_TOKENS=1024
+```
+
 ## Custom Model Provider
 
 You can configure strands to use a different model provider with specific settings by passing in the following arguments:

--- a/src/strands_agents_builder/strands.py
+++ b/src/strands_agents_builder/strands.py
@@ -39,8 +39,8 @@ from strands_agents_builder.utils.welcome_utils import render_goodbye_message, r
 
 # Custom tools, handlers, utils
 from tools import (
-    strand,
     store_in_kb,
+    strand,
     welcome,
 )
 

--- a/tools/rich_interface.py
+++ b/tools/rich_interface.py
@@ -1,7 +1,6 @@
 import textwrap
 from typing import Any
 
-from strands.types.tools import ToolResult, ToolUse
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -10,6 +9,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
+from strands.types.tools import ToolResult, ToolUse
 
 TOOL_SPEC = {
     "name": "rich_interface",


### PR DESCRIPTION
- Set Claude 3.7 Sonnet as default model with max tokens (64000)
- Extend timeouts to 15 minutes (900s) to prevent API timeouts
- Add adaptive retries for improved reliability
- Enable thinking capability with 2048 token budget
- Add STRANDS_MAX_TOKENS and STRANDS_BUDGET_TOKENS env variables
- Document configuration options in README

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
