### PR TITLE
Fix AttributeError: 'dict' object has no attribute 'merge' in BedrockModel

### DIFF
--- a/src/strands_agents_builder/models/bedrock.py
+++ b/src/strands_agents_builder/models/bedrock.py
@@ -1,5 +1,6 @@
 """Create instance of SDK's Bedrock model provider."""
 
+from botocore.config import Config as BotocoreConfig
 from strands.models import BedrockModel
 from strands.types.models import Model
 from typing_extensions import Unpack
@@ -14,5 +15,8 @@ def instance(**model_config: Unpack[BedrockModel.BedrockConfig]) -> Model:
     Returns:
         Bedrock model provider.
     """
+    # Handle conversion of boto_client_config from dict to BotocoreConfig
+    if "boto_client_config" in model_config and isinstance(model_config["boto_client_config"], dict):
+        model_config["boto_client_config"] = BotocoreConfig(**model_config["boto_client_config"])
 
     return BedrockModel(**model_config)


### PR DESCRIPTION
This PR fixes a critical bug in the Bedrock model initialization that occurs when `boto_client_config` is passed as a dictionary from JSON configuration parsing.

### Problem
- When launching Strands with Bedrock configuration, users encounter: `AttributeError: 'dict' object has no attribute 'merge'`
- The error occurs because the `BedrockModel.__init__` method expects `boto_client_config` to be a `BotocoreConfig` object, but configuration parsing from JSON creates a plain dictionary
- The code attempts to call `.merge()` on the dictionary, which doesn't have this method

### Solution
- Added type conversion in the `instance()` function to detect when `boto_client_config` is a dictionary
- Convert the dictionary to a proper `BotocoreConfig` object before passing it to `BedrockModel`
- Added the necessary import for `BotocoreConfig` from `botocore.config`

### Changes
- **File**: `src/strands_agents_builder/models/bedrock.py`
- **Added**: Import for `BotocoreConfig`
- **Added**: Type conversion logic to handle dict → `BotocoreConfig` conversion

### Testing
This fix addresses the root cause by handling the type conversion at the appropriate layer (where configuration is processed before model instantiation) rather than adding workarounds in the core model implementation.