### PR TITLE
fix: correctly handle keyboard interrupts + stop spinners on error

### DIFF
--- a/src/strands_agents_builder/strands.py
+++ b/src/strands_agents_builder/strands.py
@@ -133,7 +133,7 @@ def main():
             render_welcome_message(welcome_text)
         while True:
             try:
-                user_input = get_user_input("\n~ ")
+                user_input = get_user_input("\n~ ", default="", keyboard_interrupt_return_default=False)
                 if user_input.lower() in ["exit", "quit"]:
                     render_goodbye_message()
                     break
@@ -177,6 +177,7 @@ def main():
                 render_goodbye_message()
                 break
             except Exception as e:
+                callback_handler(force_stop=True)  # Stop spinners
                 print(f"\nError: {str(e)}")
 
 

--- a/tests/test_strands.py
+++ b/tests/test_strands.py
@@ -41,6 +41,9 @@ class TestInteractiveMode:
         # Verify welcome message was rendered
         mock_welcome_message.assert_called_once()
 
+        # Verify user input was called with the correct parameters
+        mock_user_input.assert_called_with("\n~ ", default="", keyboard_interrupt_return_default=False)
+
         # Verify user input was processed
         mock_agent.assert_called_with("test query", system_prompt=mock.ANY)
 
@@ -107,7 +110,7 @@ class TestInteractiveMode:
     ):
         """Test handling of empty input"""
         # Setup mocks - empty input followed by exit
-        mock_user_input.side_effect = ["", "exit"]
+        mock_user_input.side_effect = ["", "   ", "\t", "exit"]
 
         # Mock sys.argv
         monkeypatch.setattr(sys, "argv", ["strands"])
@@ -167,7 +170,8 @@ class TestInteractiveMode:
     @mock.patch.object(strands, "get_user_input")
     @mock.patch.object(strands, "Agent")
     @mock.patch.object(strands, "print")
-    def test_general_exception_handling(self, mock_print, mock_agent, mock_input):
+    @mock.patch.object(strands, "callback_handler")
+    def test_general_exception_handling(self, mock_callback_handler, mock_print, mock_agent, mock_input):
         """Test handling of general exceptions in interactive mode"""
         # Setup mocks
         mock_agent_instance = mock.MagicMock()
@@ -186,6 +190,9 @@ class TestInteractiveMode:
 
         # Verify error was printed
         mock_print.assert_any_call("\nError: Test error")
+
+        # Verify callback_handler was called to stop spinners
+        mock_callback_handler.assert_called_once_with(force_stop=True)
 
 
 class TestCommandLine:


### PR DESCRIPTION
## Description
* Correctly handle keyboard interrupts by exiting the application
* Stop spinners on error

**IMPORTANT: This PR depends on https://github.com/strands-agents/tools/pull/37 and must be merged after it**

## Type of Change
- Bug fix

## Testing
* `hatch fmt`
* `hatch run test-lint`
* `hatch test --all`
* Manually tested `strands` in the CLI

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [NO - depends on https://github.com/strands-agents/tools/pull/37] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
