### PR TITLE
feat: upgrade to Claude Sonnet 4 model

### DIFF
--- a/.prompt
+++ b/.prompt
@@ -182,7 +182,7 @@ from botocore.config import Config
 
 # Configure Bedrock model with maximum capabilities
 model = BedrockModel(
-    model_id="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
     max_tokens=int(os.getenv("STRANDS_MAX_TOKENS", "64000")),  # Maximized token output
     boto_client_config=Config(
         read_timeout=900,  # 15 min timeout for long operations
@@ -378,7 +378,7 @@ export STRANDS_SYSTEM_PROMPT="Your custom prompt here"
    - Create agents that can collaborate through shared interfaces
 
 6. **Maximizing Bedrock Performance**
-   - Use Claude 3.7 Sonnet for best reasoning capabilities
+   - Use the latest Claude Sonnet model available for best reasoning capabilities
    - Configure extended timeouts for complex reasoning tasks
    - Enable thinking capability with appropriate token budget
    - Use maximal output tokens to handle complex tool responses

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Strands comes with optimized, maxed-out configuration settings for the Bedrock m
 
 ```json
 {
-    "model_id": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-    "max_tokens": 64000,
+    "model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    "max_tokens": 32767,
     "boto_client_config": {
         "read_timeout": 900,
         "connect_timeout": 900,
@@ -150,8 +150,8 @@ Strands comes with optimized, maxed-out configuration settings for the Bedrock m
 ```
 
 These settings provide:
-- Claude 3.7 Sonnet (latest high-performance model)
-- Maximum token output (64,000 tokens)
+- Claude Sonnet 4 (latest high-performance model)
+- Maximum token output (32,768 tokens)
 - Extended timeouts (15 minutes) for complex operations
 - Automatic retries with adaptive backoff
 - Enabled thinking capability with 2,048 token budget for recursive reasoning

--- a/src/strands_agents_builder/utils/model_utils.py
+++ b/src/strands_agents_builder/utils/model_utils.py
@@ -11,8 +11,8 @@ from strands.types.models import Model
 
 # Default model configuration
 DEFAULT_MODEL_CONFIG = {
-    "model_id": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-    "max_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "64000")),
+    "model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    "max_tokens": int(os.getenv("STRANDS_MAX_TOKENS", "32768")),
     "boto_client_config": Config(
         read_timeout=900,
         connect_timeout=900,


### PR DESCRIPTION
## Overview
This PR upgrades the default model configuration from Claude 3.7 Sonnet to Claude Sonnet 4.

## Changes
- Updated `model_id` from `us.anthropic.claude-3-7-sonnet-20250219-v1:0` to `us.anthropic.claude-sonnet-4-20250514-v1:0`
- Updated model references in:
  - `.prompt` file
  - `README.md`
  - `src/strands_agents_builder/utils/model_utils.py`
- Adjusted `max_tokens` to 32768 for Sonnet 4 compatibility
- Updated documentation to reflect latest model capabilities

## Benefits
- Enhanced reasoning capabilities
- Improved performance
- Access to latest Claude model features
- Better tool execution and analysis

## Testing
Tested with local configuration to ensure compatibility.

## Type of Change
- [x] Feature enhancement
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update