### PR TITLE
docs(readme): fix link to custom model provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ strands --model-provider ollama --model-config '{"model_id": <ID>}'
 
 Strands Agent Builder is packaged with `bedrock` and `ollama`.
 
-If you have implemented a custom model provider ([instructions](<LINK>)) and would like to use it with strands, create a python module under the directory "$CWD/.models" and expose an `instance` function that returns an instance of your provider. As an example, assume you have:
+If you have implemented a custom model provider ([instructions](https://strandsagents.com/latest/user-guide/concepts/model-providers/custom_model_provider/)) and would like to use it with strands, create a python module under the directory "$CWD/.models" and expose an `instance` function that returns an instance of your provider. As an example, assume you have:
 
 ```bash
 $ cat ./.models/custom_model.py


### PR DESCRIPTION
## Description
fix link to custom model provider docs

## Related Issues
https://github.com/strands-agents/agent-builder/issues/23

## Documentation PR
N/A

## Type of Change
- Bug fix (broken README link)
- Documentation update

## Testing
Viewed the changes in a markdown renderer and verified the link.

## Checklist
- [X] I have read the CONTRIBUTING document
- [-] I have added tests that prove my fix is effective or my feature works
- [-] I have updated the documentation accordingly
- [-] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
