### PR TITLE
feat: enable interleaved thinking for default model configuration with Claude 4 Sonnet

### DIFF
--- a/src/strands_agents_builder/utils/model_utils.py
+++ b/src/strands_agents_builder/utils/model_utils.py
@@ -19,10 +19,11 @@ DEFAULT_MODEL_CONFIG = {
         retries=dict(max_attempts=3, mode="adaptive"),
     ),
     "additional_request_fields": {
+        "anthropic_beta": ["interleaved-thinking-2025-05-14"],
         "thinking": {
             "type": os.getenv("STRANDS_THINKING_TYPE", "enabled"),
             "budget_tokens": int(os.getenv("STRANDS_BUDGET_TOKENS", "2048")),
-        }
+        },
     },
     "cache_tools": os.getenv("STRANDS_CACHE_TOOLS", "default"),
     "cache_prompt": os.getenv("STRANDS_CACHE_PROMPT", "default"),


### PR DESCRIPTION
## Description
enable interleaved thinking for default model configuration with Claude 4 Sonnet

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
- New feature

## Testing
* `hatch fmt`
* `hatch test`
* Manually ran the agent-builder with a query: `is the ISS closer to NYC or Seattle right now?`. Confirmed that interleaved thinking was displayed in the CLI


## Checklist
- [X] I have read the CONTRIBUTING document
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
