### PR TITLE
Windows: Remove cron tool + document missing tools when on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Strands comes with a comprehensive set of built-in tools:
 
 - **agent_graph**: Create and manage graphs of agents
 - **calculator**: Perform mathematical operations
-- **cron**: Task scheduling with cron jobs
+- **cron**: Task scheduling with cron jobs *(not available on Windows)*
 - **current_time**: Get the current date and time
 - **editor**: File editing operations like line edits, search, and undo
 - **environment**: Manage environment variables
@@ -83,9 +83,9 @@ Strands comes with a comprehensive set of built-in tools:
 - **load_tool**: Dynamically load more tools at runtime
 - **memory**: Agent memory persistence in Amazon Bedrock Knowledge Bases
 - **nova_reels**: Create AI generated videos with Nova Reels on Amazon Bedrock
-- **python_repl**: Run Python code
+- **python_repl**: Run Python code *(not available on Windows)*
 - **retrieve**: Semantically retrieve data from Amazon Bedrock Knowledge Bases for RAG, memory, and other purposes
-- **shell**: Execute shell commands
+- **shell**: Execute shell commands *(not available on Windows)*
 - **slack**: Slack integration with real-time events, API access, and message sending
 - **speak**: Generate speech from text using macOS say command or Amazon Polly
 - **stop**: Force stop the agent event loop

--- a/src/strands_agents_builder/tools.py
+++ b/src/strands_agents_builder/tools.py
@@ -49,7 +49,6 @@ def get_tools() -> dict[str, Any]:
     tools = {
         "agent_graph": agent_graph,
         "calculator": calculator,
-        "cron": cron,
         "current_time": current_time,
         "editor": editor,
         "environment": environment,
@@ -86,6 +85,7 @@ def get_tools() -> dict[str, Any]:
         )
 
         tools |= {
+            "cron": cron,
             "python_repl": python_repl,
             "shell": shell,
         }


### PR DESCRIPTION


## Description

We're trying to improve the windows experience on windows, making strands more runnable.  After testing various tools, I noticed that `cron` doesn't work since the crontab binary doesn't exist, so remove it when running on windows.

Also called out in the readme the 3 tools that do not run on windows.

## Related Issues

strands-agents/tools#17

## Documentation PR

n/a

## Type of Change
- Bug fix

## Testing

Manually running strands and having it test the tools

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`

## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
