### PR TITLE
fix: udpate agent system_prompt reference

### DIFF
--- a/src/strands_agents_builder/strands.py
+++ b/src/strands_agents_builder/strands.py
@@ -112,11 +112,13 @@ def main():
                     welcome_text = ""
 
                     if welcome_result["status"] == "success":
+                        # Combine welcome text with base system prompt
                         welcome_text = welcome_result["content"][0]["text"]
+                        agent.system_prompt = f"{base_system_prompt}\n\nWelcome Text Reference:\n{welcome_text}"
+                    else:
+                        agent.system_prompt = base_system_prompt
 
-                    # Combine welcome text with base system prompt
-                    combined_system_prompt = f"{base_system_prompt}\n\nWelcome Text Reference:\n{welcome_text}"
-                    response = agent(user_input, system_prompt=combined_system_prompt)
+                    response = agent(user_input)
 
                     if knowledge_base_id:
                         # Store conversation in knowledge base

--- a/tests/test_strands.py
+++ b/tests/test_strands.py
@@ -45,7 +45,7 @@ class TestInteractiveMode:
         mock_user_input.assert_called_with("\n~ ", default="", keyboard_interrupt_return_default=False)
 
         # Verify user input was processed
-        mock_agent.assert_called_with("test query", system_prompt=mock.ANY)
+        mock_agent.assert_called_with("test query")
 
         # Verify goodbye message was rendered
         mock_goodbye_message.assert_called_once()
@@ -395,13 +395,9 @@ class TestKnowledgeBaseIntegration:
         with mock.patch.object(strands, "render_welcome_message"), mock.patch.object(strands, "render_goodbye_message"):
             strands.main()
 
-        # Extract the system_prompt from the agent call
-        call_args, call_kwargs = mock_agent.call_args
-        system_prompt = call_kwargs.get("system_prompt")
-
         # Verify system prompt includes both base prompt and welcome text
-        assert base_system_prompt in system_prompt
-        assert "Custom welcome text" in system_prompt
+        assert base_system_prompt in mock_agent.system_prompt
+        assert "Custom welcome text" in mock_agent.system_prompt
 
     def test_welcome_message_failure(
         self,
@@ -430,10 +426,5 @@ class TestKnowledgeBaseIntegration:
         with mock.patch.object(strands, "render_welcome_message"), mock.patch.object(strands, "render_goodbye_message"):
             strands.main()
 
-        # Verify agent was called with system prompt that includes welcome text reference
-        # Even with error status, the code adds a "Welcome Text Reference:" section (just empty)
-        expected_system_prompt = f"{base_system_prompt}\n\nWelcome Text Reference:\n"
-        call_args, call_kwargs = mock_agent.call_args
-        system_prompt = call_kwargs.get("system_prompt")
-
-        assert system_prompt == expected_system_prompt
+        # Verify agent was called with system prompt that excludes welcome text reference
+        assert mock_agent.system_prompt == base_system_prompt


### PR DESCRIPTION
## Description
We introduced a backwards-incompatible change in the recent strands 0.2.0 release. This PR fixes that in the agent-builder

## Related Issues
https://github.com/strands-agents/sdk-python/commit/a3925096e78d924b5ddcc4dbf74fa1da503ba29f

## Documentation PR
N/A

## Type of Change
- Bug fix


## Testing

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
