### PR TITLE
chore: explicitly set load_tools_from_directory on Agent initilizations

### DIFF
--- a/.prompt
+++ b/.prompt
@@ -204,6 +204,7 @@ agent = Agent(
     callback_handler=custom_handler,  # Optional custom output handling
     max_parallel_tools=4,  # Configure parallel tool execution
     record_direct_tool_call=True,  # Record direct tool calls in history
+    load_tools_from_directory=True, # Auto load tools from tools directory
     hot_reload_tools=True  # Reload tools if changed at runtime
 )
 ```

--- a/src/strands_agents_builder/strands.py
+++ b/src/strands_agents_builder/strands.py
@@ -58,6 +58,7 @@ def main():
         tools=tools,
         system_prompt=system_prompt,
         callback_handler=callback_handler,
+        load_tools_from_directory=True,
     )
 
     # Process query or enter interactive mode

--- a/tools/welcome.py
+++ b/tools/welcome.py
@@ -16,7 +16,7 @@ DEFAULT_WELCOME_TEXT = '''# 🚀 STRANDS AGENTS SDK: Self-Extending AI Tool Buil
 from strands import Agent, tool
 from strands_tools import load_tool, shell, editor
 
-agent = Agent(tools=[load_tool, shell, editor])
+agent = Agent(tools=[load_tool, shell, editor], load_tools_from_directory=True)
 ```
 
 ### 2️⃣ Tool Definition Pattern


### PR DESCRIPTION
## Description

In https://github.com/strands-agents/sdk-python/pull/419, a breaking change is being made to default the load_tools_from_directory to False. To avoid breaking the autonomous tool generating capabilities in this package, we must explicitly set load_tools_from_directory to True.

## Related Issues
https://github.com/strands-agents/sdk-python/pull/419

## Documentation PR
[Link to related associated PR in the agent-docs repo]

## Type of Change
- Other (please describe): Fix to prepare for breaking change in sdk

[Choose one of the above types of changes]


## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
