### PR TITLE
Update builder with updates from 0.3.0 SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "strands-agents[ollama]>=0.1.0,<1.0.0",
+    "strands-agents[ollama]>=0.3.0,<1.0.0",
     "strands-agents-tools>=0.1.0,<1.0.0",
     "rich>=14.0.0,<15.0.0",
     "prompt_toolkit>=3.0.51,<4.0.0",
@@ -50,6 +50,7 @@ dev = [
     "hatch>=1.0.0,<2.0.0",
     "mypy>=1.0.0,<2.0.0",
     "pre-commit>=3.2.0,<4.2.0",
+    "pytest>=7.0.0",
     "ruff>=0.4.4,<1.0.0",
 ]
 docs = [

--- a/src/strands_agents_builder/models/bedrock.py
+++ b/src/strands_agents_builder/models/bedrock.py
@@ -1,8 +1,7 @@
 """Create instance of SDK's Bedrock model provider."""
 
 from botocore.config import Config as BotocoreConfig
-from strands.models import BedrockModel
-from strands.types.models import Model
+from strands.models import BedrockModel, Model
 from typing_extensions import Unpack
 
 

--- a/src/strands_agents_builder/models/ollama.py
+++ b/src/strands_agents_builder/models/ollama.py
@@ -2,8 +2,8 @@
 
 from typing import Optional
 
+from strands.models import Model
 from strands.models.ollama import OllamaModel
-from strands.types.models import Model
 from typing_extensions import Unpack
 
 

--- a/src/strands_agents_builder/utils/model_utils.py
+++ b/src/strands_agents_builder/utils/model_utils.py
@@ -7,7 +7,7 @@ import pathlib
 from typing import Any
 
 from botocore.config import Config
-from strands.types.models import Model
+from strands.models import Model
 
 # Default model configuration
 DEFAULT_MODEL_CONFIG = {

--- a/tests/tools/test_strand.py
+++ b/tests/tools/test_strand.py
@@ -37,9 +37,7 @@ class TestStrandTool:
     def test_strand_empty_query(self):
         """Test handling of empty query"""
         # Call the strand tool with empty query
-        tool_use = {"toolUseId": "test_id", "input": {"query": ""}}
-
-        result = strand(tool_use)
+        result = strand(query="")
 
         # Verify error response
         assert result["status"] == "error"
@@ -54,12 +52,8 @@ class TestStrandTool:
             mock_agent_instance.return_value = {"status": "success", "content": [{"text": "Agent response"}]}
 
             # Call the strand tool with custom prompt
-            tool_use = {
-                "toolUseId": "test_id",
-                "input": {"query": "test query", "system_prompt": "Custom system prompt"},
-            }
             # Store result to validate return value
-            result = strand(tool_use)
+            result = strand(query="test query", system_prompt="Custom system prompt")
             assert result["status"] == "success"
 
             # Verify agent was created with custom prompt


### PR DESCRIPTION

## Description

There's various changes in 0.3.0 for which the agent builder needs to be updated.

+ set minimum sdk version to be 0.3.0 because of the api changes.

## Related Issues

https://github.com/strands-agents/sdk-python/releases/tag/v0.3.0

## Documentation PR

N/A

## Type of Change

Bug fix


## Testing
[How have you tested the change?]

* `hatch fmt --linter`
* `hatch fmt --formatter`
* `hatch test --all`


## Checklist
- [X] I have read the CONTRIBUTING document
- [X] I have added tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
