### PR TITLE
Fix incorrect command line example in Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ strands
 # Build a custom tool and use it immediately
 strands "Create a tool named sentiment_analyzer that analyzes text sentiment and test it with some examples"
 
-# Pipe content to build an agent based on specifications
+# Piped input with additional instructions (requires BYPASS_TOOL_CONSENT=true)
 cat agent-spec.txt | strands "Build a specialized agent based on these specifications"
 
 # Use with knowledge base to extend existing tools
@@ -226,6 +226,28 @@ Strands Agent Builder also provides customization through environment variables:
 ## Exit
 
 Type `exit`, `quit`, or press `Ctrl+C`/`Ctrl+D`
+
+## Usage Patterns
+
+Strands Agent Builder supports these input methods:
+
+**Direct command:**
+```
+strands "Your instruction here"
+```
+
+**Piped input:**
+```
+cat your-file.txt | strands
+echo "Your instruction" | strands
+```
+
+**Combined piped input with additional instructions:**
+```
+# Requires BYPASS_TOOL_CONSENT=true to avoid confirmation prompts
+export BYPASS_TOOL_CONSENT=true
+cat agent-spec.txt | strands "Build a specialized agent based on these specifications"
+```
 
 ## Contributing ❤️
 


### PR DESCRIPTION
## Problem:
The README documentation was incomplete regarding usage patterns for the strands command, particularly when combining piped input with additional command arguments.

## Solution:
- Updated Quick Start section to show the working combined usage pattern
- Enhanced Usage Patterns section to document all three supported input methods:
  1. Direct command arguments only
  2. Piped input only  
  3. Combined piped input with additional instructions (requires BYPASS_TOOL_CONSENT=true)
- Clarified that combining piped input with command arguments requires setting BYPASS_TOOL_CONSENT=true to bypass tool confirmation prompts

## Testing:
- ✅ Verified `strands "instruction"` works (direct command only)
- ✅ Verified `cat agent-spec.txt | strands "Build a specialized agent based on these specifications"` works when `BYPASS_TOOL_CONSENT=true`

## Changes:
- Added working example of combined usage in Quick Start section
- Expanded Usage Patterns section with comprehensive documentation
- Documented the BYPASS_TOOL_CONSENT requirement for combined usage

## Type of Change
- ✅ Documentation improvement
- ✅ Clarification of existing functionality